### PR TITLE
Rename 2 assertion properties: 'then' and 'eventually'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ const store = chai.createReduxStore({reducer, middleware: [thunk]});
 // when
 store.dispatch(fetchData());
 // then
-expect(store).to.eventually.have
+expect(store).to.finally.have
     .dispatched('FETCH')
-    .then.dispatched(
+    .next.dispatched(
         {type: 'SUCCESSFUL', name: 'redux'})
     .notify(done);
 ```
@@ -107,17 +107,17 @@ expect(store).to.have
     .and.state.like({value: 42});
 ``` 
 
-**.then.state(state: any)**
+**.next.state(state: any)**
 
 Asserts that *state* is next state in state history.
 
 ```
 expect(store).to.have
     .state({loading: false})
-    .then.state({loading: true});
+    .next.state({loading: true});
 ``` 
 
-then.state and then.dispatched cannot be mixed.
+next.state and next.dispatched cannot be mixed.
 
 **.dispatched(action: String, Object)**
 
@@ -130,26 +130,26 @@ expect(store).to.have
     .dispatched('LOAD');
 ``` 
 
-**.then.dispatched(state: any)**
+**.next.dispatched(state: any)**
 
 Asserts that *state* is next state in state history.
 
 ```
 expect(store).to.have
     .dispatched('LOAD')
-    .then.dispatched({type: 'RESET'});
+    .next.dispatched({type: 'RESET'});
 ``` 
 
-then.state and then.dispatched cannot be mixed.
+next.state and next.dispatched cannot be mixed.
 
-**.eventually**, **.notify(done: function)**
+**.finally**, **.notify(done: function)**
 
 Asserts that history contains *state* or *action*. 
 It will wait till store history contains *state* or *action*. 
 Once state is found *done* is notified.
 
 ```
-expect(store).to.have.eventually
+expect(store).to.have.finally
     .state({loading: false, value: null})
     .and.state.like({loading: true})
     .and.dispatched('LOAD')

--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,9 @@ import _defaults from 'lodash.defaults';
 import { createStore, combineReducers, applyMiddleware } from 'redux';
 
 const partialEquals = (obj, exptected) => {
-  let allExpectedKeys = Object.keys(exptected);
-  let partialObject = _pick(obj, allExpectedKeys);
-  return _isEqual(partialObject, exptected);
+    let allExpectedKeys = Object.keys(exptected);
+    let partialObject = _pick(obj, allExpectedKeys);
+    return _isEqual(partialObject, exptected);
 };
 
 const isFunction = (value) => typeof value === 'function';
@@ -56,7 +56,7 @@ export default (chai, utils) => {
             let result;
             try {
                 result = next(action);
-            }catch (e) {
+            } catch (e) {
                 console.error('Error when calling middleware. ' +
                     'Did you forget to setup a middleware?');
                 throw e;
@@ -64,7 +64,7 @@ export default (chai, utils) => {
             let state = reduxStore.getState();
             reduxStore.__states.push(state);
             reduxStore.__history.push({ action, state: state });
-            reduxStore.__listener.forEach(listener => {listener()});
+            reduxStore.__listener.forEach(listener => { listener() });
             return result;
         };
 
@@ -118,8 +118,8 @@ export default (chai, utils) => {
     let verifyValues = function (expectedState, options = {}) {
         // declare and initiate
         let { compareState, values } = _defaults(options, defaultOptions);
-        const isAsync = utils.flag(this, 'eventually') || false;
-        const isChained = utils.flag(this, 'then') || false;
+        const isAsync = utils.flag(this, 'finally') || false;
+        const isChained = utils.flag(this, 'next') || false;
         const lastIndex = () => utils.flag(this, 'lastIndex');
         const chainIndex = utils.flag(this, 'chainIndex') || 0;
 
@@ -154,8 +154,8 @@ export default (chai, utils) => {
         updateAssertions(false);
         // update chain count
         utils.flag(this, 'chainIndex', chainIndex + 1);
-        // reset then flag. Only then can set it to true
-        utils.flag(this, 'then', false);
+        // reset next flag. Only then can set it to true
+        utils.flag(this, 'next', false);
 
         if (isAsync === true) {
             let unsubscribe;
@@ -184,30 +184,30 @@ export default (chai, utils) => {
     };
 
     /**
-     * ### .eventually
+     * ### .finally
      *
-     * Sets the `eventually` flag.
+     * Sets the `finally` flag.
      * later used by the `dispatched`, `state` or `like` assertion.
      *
-     *     expect(store).to.eventually.have.state({loaded: true});
-     *     expect(store).to.eventually.have.dispatched('FETCH');
+     *     expect(store).to.finally.have.state({loaded: true});
+     *     expect(store).to.finally.have.dispatched('FETCH');
      *
      */
-    Assertion.addProperty('eventually', checkIfIsStoreProxyAndAddFlag('eventually'));
+    Assertion.addProperty('finally', checkIfIsStoreProxyAndAddFlag('finally'));
 
     /**
-     * ### .then
+     * ### .next
      *
-     * Sets the `then` flag.
+     * Sets the `next` flag.
      * later used by the `dispatched`, `state` or `like` assertion.
      *
-     *     expect(store).to.eventually.have.state({loaded: true});
-     *     expect(store).to.eventually.have.state.like({loaded: true});
+     *     expect(store).to.finally.have.state({loaded: true});
+     *     expect(store).to.finally.have.state.like({loaded: true});
      *
      */
-    Assertion.addProperty('then', function(){
-        checkIfIsStoreProxyAndAddFlag('then').call(this, 'then');
-        if(utils.flag(this, 'lastIndex') === undefined){
+    Assertion.addProperty('next', function () {
+        checkIfIsStoreProxyAndAddFlag('next').call(this, 'next');
+        if (utils.flag(this, 'lastIndex') === undefined) {
             utils.flag(this, 'lastIndex', -1);
         }
     });
@@ -221,14 +221,14 @@ export default (chai, utils) => {
      *     expect(store).not.to.have.state({a: 'b'});
      *     expect(store).to.have.state({b: 'a'}).and.state({b: 'b'});
      *
-     * When used in conjunction with `eventually` it will wait till store state history
+     * When used in conjunction with `finally` it will wait till store state history
      * contains `state` or timeout.
      *
-     *     expect(store).to.eventually.have.state({loaded: true});
+     *     expect(store).to.finally.have.state({loaded: true});
      *
-     * When chained with `then` it will assert store's state history contains `state`s in order.
+     * When chained with `next` it will assert store's state history contains `state`s in order.
      *
-     *     expect(store).to.have.state({b: 'a'}).then.state({b: 'b'});
+     *     expect(store).to.have.state({b: 'a'}).next.state({b: 'b'});
      *
      * @param {...String|Array|Object} state
      *
@@ -247,14 +247,14 @@ export default (chai, utils) => {
      *     expect(store).not.to.have.state.like({a: 'b'});
      *     expect(store).to.have.state({b: 'a'}).and.state.like({b: 'b'});
      *
-     * When used in conjunction with `eventually` it will wait till store state history
+     * When used in conjunction with `finally` it will wait till store state history
      * contains `state` or timeout.
      *
-     *     expect(store).to.eventually.have.state.like({loaded: true});
+     *     expect(store).to.finally.have.state.like({loaded: true});
      *
-     * When chained with `then` it will assert store's state history contains `state`s in order.
+     * When chained with `next` it will assert store's state history contains `state`s in order.
      *
-     *     expect(store).to.have.state.like({b: 'a'}).then.state({b: 'b'});
+     *     expect(store).to.have.state.like({b: 'a'}).next.state({b: 'b'});
      *
      * @param {...Array|Object|String} states
      *
@@ -291,14 +291,14 @@ export default (chai, utils) => {
      *
      *     expect(store).to.have.dispatched('FETCH');
      *
-     * When used in conjunction with `eventually` it will wait till store's action history
+     * When used in conjunction with `finally` it will wait till store's action history
      * contains `action` or timeout.
      *
-     *     expect(store).to.eventually.have.dispatched('FETCH');
+     *     expect(store).to.finally.have.dispatched('FETCH');
      *
-     * When chained with `then` it will assert store's state history contains `state`s in order.
+     * When chained with `next` it will assert store's state history contains `state`s in order.
      *
-     *     expect(store).to.have.dispatched('FETCH').then.dispatched({type: 'SUCCESSFUL'});
+     *     expect(store).to.have.dispatched('FETCH').next.dispatched({type: 'SUCCESSFUL'});
      *
      * @param {...Array|Object|String} states
      *
@@ -321,10 +321,10 @@ export default (chai, utils) => {
      * Will trigger callback once `state`, `dispatched` or `like` assertion has passed.
      * Can be used to notify testing framework that test is completed.
      *
-     *     expect(store).to.eventually.have.state({loaded: true}).notify(done);
+     *     expect(store).to.finally.have.state({loaded: true}).notify(done);
      *
      */
-    Assertion.addMethod('notify', function (notify = () => {}) {
+    Assertion.addMethod('notify', function (notify = () => { }) {
         let unsubscribe;
         const isDone = () => {
             const assertions = utils.flag(this, 'assertions') || [];

--- a/test/dispatched.js
+++ b/test/dispatched.js
@@ -21,29 +21,29 @@ describe('dispatched', () => {
         expect(store).to.have.dispatched({ type: 'TEST' });
     });
 
-    it('should eventually have action TEST', (done) => {
+    it('should finally have action TEST', (done) => {
         const store = chai.createReduxStore({ reducer });
         _delay(store.dispatch, 50, ({ type: 'TEST' }));
-        expect(store).to.have.eventually
+        expect(store).to.have.finally
             .dispatched('TEST')
             .notify(done);
     });
 
-    it('should eventually have actions TEST-1 and TEST', (done) => {
+    it('should finally have actions TEST-1 and TEST', (done) => {
         const store = chai.createReduxStore({ reducer });
         store.dispatch({ type: 'TEST-1' });
         _delay(store.dispatch, 50, ({ type: 'TEST' }));
-        expect(store).to.have.eventually
+        expect(store).to.have.finally
             .dispatched({ type: 'TEST-1' })
             .and.dispatched({ type: 'TEST' })
             .notify(done);
     });
 
-    it('should eventually have actions TEST-1, TEST', (done) => {
+    it('should finally have actions TEST-1, TEST', (done) => {
         const store = chai.createReduxStore({ reducer });
         store.dispatch({ type: 'TEST-1' });
         _delay(store.dispatch, 50, ({ type: 'TEST' }));
-        expect(store).to.have.eventually
+        expect(store).to.have.finally
             .dispatched('TEST-1')
             .and.dispatched('TEST')
             .notify(done);

--- a/test/like.js
+++ b/test/like.js
@@ -9,7 +9,7 @@ describe('like', () => {
 
     it('should wait for all states (partial deep comparison)', (done) => {
         let store = chai.createReduxStore({ reducer });
-        expect(store).to.eventually.have
+        expect(store).to.finally.have
             .state.like({ value: { firstName: 'Jane', lastName: 'Doe' } })
             .and.state.like({ value: { firstName: 'Max', lastName: 'Mustermann' } })
             .notify(done);

--- a/test/next.js
+++ b/test/next.js
@@ -5,7 +5,7 @@ import _delay from 'lodash.delay';
 
 chai.use(chaiRedux);
 
-describe('then', () => {
+describe('next', () => {
 
     it('weird chains - dispatched', (done) => {
         let store = chai.createReduxStore({ reducer });
@@ -14,7 +14,7 @@ describe('then', () => {
         _delay(store.dispatch, 50, { type: 'TRIGGER' });
         _delay(store.dispatch, 10, { type: 'LOADED' });
 
-        expect(store).to.eventually.have
+        expect(store).to.finally.have
             .dispatched('TRIGGER')
             .and.dispatched('LOADED')
             .and.dispatched('LOADED')
@@ -29,11 +29,11 @@ describe('then', () => {
         store.dispatch({ type: 'TRIGGER' });
         store.dispatch({ type: 'LOADED', firstName: 'Max', lastName: 'Mustermann' });
 
-        expect(store).to.eventually.have
+        expect(store).to.finally.have
             .dispatched('TRIGGER')
-            .then.dispatched({ type: 'LOADED', firstName: 'Max', lastName: 'Mustermann' })
-            .then.dispatched({ type: 'LOADED', firstName: 'Maria', lastName: 'Mustermann' })
-            .then.dispatched('LOADING_ERROR')
+            .next.dispatched({ type: 'LOADED', firstName: 'Max', lastName: 'Mustermann' })
+            .next.dispatched({ type: 'LOADED', firstName: 'Maria', lastName: 'Mustermann' })
+            .next.dispatched('LOADING_ERROR')
             .notify(done);
     });
 
@@ -44,23 +44,23 @@ describe('then', () => {
         store.dispatch({ type: 'TRIGGER' });
         store.dispatch({ type: 'LOADED', firstName: 'Max', lastName: 'Mustermann' });
 
-        expect(store).to.eventually.have
+        expect(store).to.finally.have
             .dispatched('TRIGGER')
-            .then.dispatched('LOADED')
-            .then.dispatched('LOADED')
-            .then.dispatched('LOADING_ERROR')
+            .next.dispatched('LOADED')
+            .next.dispatched('LOADED')
+            .next.dispatched('LOADING_ERROR')
             .notify(done);
     });
 
     it('should wait for all chained states', (done) => {
         let store = chai.createReduxStore({ reducer });
 
-        expect(store).to.eventually.have
+        expect(store).to.finally.have
             .state({ value: null, loading: false, loaded: false })
-            .then.state({ value: null, loading: true, loaded: false })
-            .then.state({ value: { firstName: 'Jane', lastName: 'Doe' }, loading: false, loaded: true })
-            .then.state({ value: { firstName: 'Max', lastName: 'Mustermann' }, loading: false, loaded: true })
-            .then.state({ value: null, loading: false, loaded: false })
+            .next.state({ value: null, loading: true, loaded: false })
+            .next.state({ value: { firstName: 'Jane', lastName: 'Doe' }, loading: false, loaded: true })
+            .next.state({ value: { firstName: 'Max', lastName: 'Mustermann' }, loading: false, loaded: true })
+            .next.state({ value: null, loading: false, loaded: false })
             .notify(done);
 
         store.dispatch({ type: 'TRIGGER' });
@@ -79,16 +79,16 @@ describe('then', () => {
 
         expect(store).to.have
             .state({ value: null, loading: false, loaded: false })
-            .then.have.state({ value: null, loading: true, loaded: false })
-            .then.have.state({ value: { firstName: 'Jane', lastName: 'Doe' }, loading: false, loaded: true })
-            .then.have.state({ value: { firstName: 'Max', lastName: 'Mustermann' }, loading: false, loaded: true })
-            .then.have.state({ value: null, loading: false, loaded: false });
+            .next.have.state({ value: null, loading: true, loaded: false })
+            .next.have.state({ value: { firstName: 'Jane', lastName: 'Doe' }, loading: false, loaded: true })
+            .next.have.state({ value: { firstName: 'Max', lastName: 'Mustermann' }, loading: false, loaded: true })
+            .next.have.state({ value: null, loading: false, loaded: false });
     });
 
-    it('should not fail if then is used as first state check', () => {
+    it('should not fail if next is used as first state check', () => {
         let store = chai.createReduxStore({ reducer: reducer });
         expect(store).to.have
-            .then.state({ value: null, loading: false, loaded: false });
+            .next.state({ value: null, loading: false, loaded: false });
     });
 
     it('should only work in correct order', () => {
@@ -108,9 +108,9 @@ describe('then', () => {
 
         const wrongChain = () => expect(store).to.have
             .dispatched({ type: 'TRIGGER' })
-            .then.dispatched({ type: 'LOADED', firstName: 'Max', lastName: 'Mustermann' })
-            .then.dispatched({ type: 'LOADED', firstName: 'Jane', lastName: 'Doe' })
-            .then.dispatched({ type: 'LOADING_ERROR' });
+            .next.dispatched({ type: 'LOADED', firstName: 'Max', lastName: 'Mustermann' })
+            .next.dispatched({ type: 'LOADED', firstName: 'Jane', lastName: 'Doe' })
+            .next.dispatched({ type: 'LOADING_ERROR' });
 
         expect(wrongChain).to.throw(/expected/)
     });

--- a/test/state.js
+++ b/test/state.js
@@ -15,7 +15,7 @@ describe('states', () => {
         store.dispatch({ type: 'LOADED', firstName: 'Max', lastName: 'Mustermann' });
         _delay(store.dispatch, 50, { type: 'LOADING_ERROR' });
 
-        expect(store).to.eventually.have
+        expect(store).to.finally.have
             .state({ value: null, loading: false, loaded: false })
             .and.state({ value: null, loading: true, loaded: false })
             .and.state({ value: { firstName: 'Jane', lastName: 'Doe' }, loading: false, loaded: true })

--- a/test/thunk-store.js
+++ b/test/thunk-store.js
@@ -22,19 +22,19 @@ describe('async update', () => {
     it('should wait for state', (done) => {
         const store = chai.createReduxStore({ reducer, middleware: thunk });
         store.dispatch(delayedAction(12));
-        expect(store).to.eventually.have.state({ updated: true, value: 12 }).notify(done);
+        expect(store).to.finally.have.state({ updated: true, value: 12 }).notify(done);
     });
 
     it('should wait for state like', (done) => {
         const store = chai.createReduxStore({ reducer, middleware: thunk });
         store.dispatch(delayedAction(12));
-        expect(store).to.eventually.have.state.like({ value: 12 }).notify(done);
+        expect(store).to.finally.have.state.like({ value: 12 }).notify(done);
     });
 
-    it('should eventually have dispatched action ASYNC_ACTION', (done) => {
+    it('should finally have dispatched action ASYNC_ACTION', (done) => {
         const store = chai.createReduxStore({ reducer, middleware: thunk });
         store.dispatch(delayedAction(13));
-        expect(store).to.eventually.have.dispatched('ASYNC_ACTION').notify(done);
+        expect(store).to.finally.have.dispatched('ASYNC_ACTION').notify(done);
     });
 
 });


### PR DESCRIPTION
These two assertion properties use the same keywords as `chai-as-promised`, which results in conflicts that makes it impossible to use  `chai-as-promised` and `chai-redux` at the same time.

`then` -> `next`;
`eventually` -> `finally`.